### PR TITLE
feat: Add `network` icon

### DIFF
--- a/icons/network.svg
+++ b/icons/network.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M9 2V8H15V2H9Z" />
+  <path d="M8 16H2V22H8V16Z" />
+  <path d="M12 8V12M12 12H5V16M12 12H19V16" />
+  <path d="M16 16V22H22V16H16Z" />
+</svg>

--- a/icons/network.svg
+++ b/icons/network.svg
@@ -9,8 +9,8 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <path d="M9 2V8H15V2H9Z" />
-  <path d="M8 16H2V22H8V16Z" />
+  <rect x="9" y="2" width="6" height="6" />
+  <rect x="16" y="16" width="6" height="6" />
+  <rect x="2" y="16" width="6" height="6" />
   <path d="M12 8V12M12 12H5V16M12 12H19V16" />
-  <path d="M16 16V22H22V16H16Z" />
 </svg>


### PR DESCRIPTION
<img width="517" alt="Screenshot 2020-06-28 at 12 54 25" src="https://user-images.githubusercontent.com/62398724/85946752-804f1a00-b93e-11ea-9c41-24511cf49ea5.png">

Related: https://github.com/feathericons/feather/pull/652, https://github.com/feathericons/feather/issues/94