### PR TITLE
refactor: Update `git-commit` icon

### DIFF
--- a/icons/git-commit.svg
+++ b/icons/git-commit.svg
@@ -9,7 +9,7 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <circle cx="12" cy="12" r="4" />
-  <line x1="1.05" y1="12" x2="7" y2="12" />
-  <line x1="17.01" y1="12" x2="22.96" y2="12" />
+  <circle cx="12" cy="12" r="3" />
+  <line x1="3" y1="12" x2="9" y2="12" />
+  <line x1="15" y1="12" x2="21" y2="12" />
 </svg>


### PR DESCRIPTION
<img width="832" alt="Screenshot 2020-07-02 at 09 41 12" src="https://user-images.githubusercontent.com/62398724/86337975-b4ca1b00-bc49-11ea-845b-8db32f99cba5.png">

- Added padding of 2px (same as the other git icons).
- Made the circle the same size as the other git icons.