### PR TITLE
feat: Add `undo` and `redo` icons

### DIFF
--- a/icons/redo.svg
+++ b/icons/redo.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polyline transform="matrix(-1 0 0 1 22.742 5.4846)" points="1 4 1 10 7 10"/>
+  <path d="m2.2522 14.485c2.2082-6.2402 10.171-8.0418 14.85-3.36l4.64 4.36"/>  
+</svg>

--- a/icons/redo.svg
+++ b/icons/redo.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline transform="matrix(-1 0 0 1 23 6)" points="1 4 1 10 7 10"/>
+  <polyline points="22 10 22 16 16 16" />
   <path d="m1.9935 16c1.8136-6.5424 9.5593-9.4823 15.36-4.36l4.64 4.36" />
 </svg>

--- a/icons/redo.svg
+++ b/icons/redo.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline transform="matrix(-1 0 0 1 22.994 5.9996)" points="1 4 1 10 7 10"/>
-  <path d="m1.9935 16c1.8136-6.5424 9.5593-9.4823 15.36-4.36l4.64 4.36" stroke-width="1.9994"/>
+  <polyline transform="matrix(-1 0 0 1 23 6)" points="1 4 1 10 7 10"/>
+  <path d="m1.9935 16c1.8136-6.5424 9.5593-9.4823 15.36-4.36l4.64 4.36" />
 </svg>

--- a/icons/redo.svg
+++ b/icons/redo.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
- <polyline transform="matrix(-1,0,0,1,23,5)" points="1 4 1 10 7 10"/>
- <path d="m2.5102 14c2.2082-6.2402 10.171-8.0418 14.85-3.36l4.64 4.36"/>
+  <polyline transform="matrix(-1 0 0 1 22.994 5.9996)" points="1 4 1 10 7 10"/>
+  <path d="m1.9935 16c1.8136-6.5424 9.5593-9.4823 15.36-4.36l4.64 4.36" stroke-width="1.9994"/>
 </svg>

--- a/icons/redo.svg
+++ b/icons/redo.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline transform="matrix(-1 0 0 1 22.742 5.4846)" points="1 4 1 10 7 10"/>
-  <path d="m2.2522 14.485c2.2082-6.2402 10.171-8.0418 14.85-3.36l4.64 4.36"/>  
+ <polyline transform="matrix(-1,0,0,1,23,5)" points="1 4 1 10 7 10"/>
+ <path d="m2.5102 14c2.2082-6.2402 10.171-8.0418 14.85-3.36l4.64 4.36"/>
 </svg>

--- a/icons/undo.svg
+++ b/icons/undo.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
- <polyline transform="translate(.9998 5.9996)" points="1 4 1 10 7 10"/>
- <path d="M 21.49,15 C 19.2818,8.7598 11.319,6.9582 6.64,11.64 L 2,16"/>
+  <polyline transform="translate(1 6)" points="1 4 1 10 7 10"/>
+  <path d="m22 16c-1.8136-6.5424-9.5593-9.4823-15.36-4.36l-4.64 4.36" stroke-width="1.9994"/>
 </svg>

--- a/icons/undo.svg
+++ b/icons/undo.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <polyline transform="translate(1.2578 5.4846)" points="1 4 1 10 7 10"/>
+  <path d="m21.748 14.485c-2.2082-6.2402-10.171-8.0418-14.85-3.36l-4.64 4.36"/>
+</svg>

--- a/icons/undo.svg
+++ b/icons/undo.svg
@@ -10,5 +10,5 @@
   stroke-linejoin="round"
 >
   <polyline transform="translate(1 6)" points="1 4 1 10 7 10"/>
-  <path d="m22 16c-1.8136-6.5424-9.5593-9.4823-15.36-4.36l-4.64 4.36" stroke-width="1.9994"/>
+  <path d="m22 16c-1.8136-6.5424-9.5593-9.4823-15.36-4.36l-4.64 4.36"/>
 </svg>

--- a/icons/undo.svg
+++ b/icons/undo.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline transform="translate(1.2578 5.4846)" points="1 4 1 10 7 10"/>
-  <path d="m21.748 14.485c-2.2082-6.2402-10.171-8.0418-14.85-3.36l-4.64 4.36"/>
+ <polyline transform="translate(.9998 5.9996)" points="1 4 1 10 7 10"/>
+ <path d="M 21.49,15 C 19.2818,8.7598 11.319,6.9582 6.64,11.64 L 2,16"/>
 </svg>

--- a/icons/undo.svg
+++ b/icons/undo.svg
@@ -10,5 +10,5 @@
   stroke-linejoin="round"
 >
   <polyline transform="translate(1 6)" points="1 4 1 10 7 10"/>
-  <path d="m22 16c-1.8136-6.5424-9.5593-9.4823-15.36-4.36l-4.64 4.36"/>
+  <path d="m22 16c-1.8136-6.5424-9.5593-9.4823-15.36-4.36l-4.64 4.36" />
 </svg>

--- a/icons/undo.svg
+++ b/icons/undo.svg
@@ -9,6 +9,6 @@
   stroke-linecap="round"
   stroke-linejoin="round"
 >
-  <polyline transform="translate(1 6)" points="1 4 1 10 7 10"/>
+  <polyline points="2 10 2 16 8 16" />
   <path d="m22 16c-1.8136-6.5424-9.5593-9.4823-15.36-4.36l-4.64 4.36" />
 </svg>


### PR DESCRIPTION
Possible response to [#60](https://github.com/feathericons/feather/issues/60) based on a suggestion to use `refresh-cw` as a starting point.

![image](https://user-images.githubusercontent.com/3356896/86460394-4b541600-bcf6-11ea-89ec-59eb151b6f77.png)
![image](https://user-images.githubusercontent.com/3356896/86460765-f82e9300-bcf6-11ea-8833-3f93e691df49.png)


